### PR TITLE
Pass the correct url to project_config class

### DIFF
--- a/modules/opencontrail_ci/manifests/zuul.pp
+++ b/modules/opencontrail_ci/manifests/zuul.pp
@@ -3,7 +3,7 @@ class opencontrail_ci::zuul(
 ) inherits opencontrail_ci::params {
 
   class { '::project_config':
-    url      => $::project_config_repo,
+    url      => $::opencontrail_ci::params::project_config_repo,
     revision => $::environment,
   }
 

--- a/modules/opencontrail_ci/manifests/zuul_launcher.pp
+++ b/modules/opencontrail_ci/manifests/zuul_launcher.pp
@@ -37,8 +37,7 @@ class opencontrail_ci::zuul_launcher(
 ) inherits opencontrail_ci::params {
 
   class { '::project_config':
-    url      => $::project_config_repo,
-    base     => $::project_config_base,
+    url      => $::opencontrail_ci::params::project_config_repo,
     revision => $::environment,
   }
 


### PR DESCRIPTION
Puppet resolves ::project_config_repo to an empty variable, breaking
Vcsrepo resource (it's passed as an empty source, breaking checkout).
Use the fully qualified name instead.