### PR TITLE
remove per-environment variables from site.pp

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -20,12 +20,6 @@ node 'logs2.opencontrail.org' {
     logserver_ssl_key  => hiera('logserver_ssl_key'),
     logserver_ssl_cert => hiera('logserver_ssl_cert'),
   }
-  accounts::user { 'zuul':
-    ensure        => present,
-    comment       => 'Zuul Launcher',
-    purge_sshkeys => true,
-    sshkeys       => hiera('zuul_ssh_public_keys'),
-  }
 }
 
 node 'zuulv3-dev.opencontrail.org' {
@@ -41,8 +35,6 @@ node 'nodepool.opencontrail.org' {
 
 node /^zuul-merger.*$/ {
   class { '::opencontrail_ci::server': }
-  class { '::opencontrail_ci::zuul_merger':
-    gearman_server => '1.1.1.39',
-  }
+  class { '::opencontrail_ci::zuul_merger': }
 }
 

--- a/modules/opencontrail_ci/manifests/logserver.pp
+++ b/modules/opencontrail_ci/manifests/logserver.pp
@@ -19,6 +19,13 @@ class opencontrail_ci::logserver (
     action => 'accept',
   }
 
+  accounts::user { 'zuul':
+    ensure        => present,
+    comment       => 'Zuul Launcher',
+    purge_sshkeys => true,
+    sshkeys       => hiera('zuul_ssh_public_keys'),
+  }
+
   vcsrepo { '/opt/os_loganalyze':
     ensure   => latest,
     provider => 'git',


### PR DESCRIPTION
make sure that we keep all per-environment variables outside of the
puppet manifests, preferable in the hiera files.