### PR TITLE
change manifests/site.pp to be environment-agnostic

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -4,17 +4,17 @@ node default {
   class { '::opencontrail_ci::server': }
 }
 
-node 'ci-puppetmaster2.opencontrail.org' {
+node /ci-puppetmaster2?.opencontrail.org/ {
   class { '::opencontrail_ci::server': }
   class { '::opencontrail_ci::puppetmaster': }
 }
 
-node 'puppetdb2.opencontrail.org' {
+node /puppetdb2?.opencontrail.org/ {
   class { '::opencontrail_ci::server': }
   class { '::opencontrail_ci::puppetdb': }
 }
 
-node 'logs2.opencontrail.org' {
+node /logs2?.opencontrail.org/ {
   class { '::opencontrail_ci::server': }
   class { '::opencontrail_ci::logserver':
     logserver_ssl_key  => hiera('logserver_ssl_key'),
@@ -22,19 +22,14 @@ node 'logs2.opencontrail.org' {
   }
 }
 
-node 'zuulv3-dev.opencontrail.org' {
+node /zuulv3(-dev)?.opencontrail.org/ {
   class { '::opencontrail_ci::zuul_scheduler': }
   class { '::zuul::web': }
   class { '::zuul::executor': }
 }
 
-node 'nodepool.opencontrail.org' {
+node /nl\d+(-dev)?.opencontrail.org/ {
   class { '::opencontrail_ci::server': }
   class { '::opencontrail_ci::nodepool_launcher': }
-}
-
-node /^zuul-merger.*$/ {
-  class { '::opencontrail_ci::server': }
-  class { '::opencontrail_ci::zuul_merger': }
 }
 


### PR DESCRIPTION
Update manifests/site.pp to support both production and development
environments, in order to avoid making unneeded changes when merging
both environments.