### PR TITLE
Create manifests for nodepool and executor nodes

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -65,3 +65,12 @@ zuul::connections:
     sshkey: '/var/lib/zuul/ssh/id_rsa'
 
 zuul::zookeeper_hosts: "zuulv3-dev.opencontrail.org:2181"
+
+# Nodepool Builder and Launcher configuration
+nodepool::git_source_repo:          "https://github.com/kklimonda/nodepool"
+nodepool::revision:                 "feature/zuulv3"
+nodepool::python_version:           3
+nodepool::scripts_dir:              "/etc/project-config/nodepool/scripts"
+nodepool::require:                  Vcsrepo[/etc/project-config]
+nodepool::install_mysql:            false
+nodepool::install_nodepool_builder: false

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -28,7 +28,17 @@ node /zuulv3(-dev)?.opencontrail.org/ {
   class { '::opencontrail_ci::zuul_merger': }
 }
 
-node /nl\d+(-dev)?.opencontrail.org/ {
+node /nl\d+(-dev|-jnpr)?.opencontrail.org/ {
   class { '::opencontrail_ci::server': }
   class { '::opencontrail_ci::nodepool_launcher': }
+}
+
+node /nb\d+(-dev|-jnpr)?.opencontrail.org/ {
+  class { '::opencontrail_ci::server': }
+  class { '::opencontrail_ci::nodepool_builder': }
+}
+
+node /ze\d+(-dev|-jnpr)?.opencontrail.org/ {
+  class { '::opencontrail_ci::server': }
+  class { '::opencontrail_ci::zuul_executor': }
 }

--- a/modules/opencontrail_ci/manifests/nodepool_builder.pp
+++ b/modules/opencontrail_ci/manifests/nodepool_builder.pp
@@ -1,4 +1,4 @@
-class opencontrail_ci::nodepool_launcher(
+class opencontrail_ci::nodepool_builder(
   $cloud_credentials = $::opencontrail_ci::params::cloud_credentials
 ) inherits opencontrail_ci::params {
 
@@ -9,7 +9,11 @@ class opencontrail_ci::nodepool_launcher(
     }
   }
 
-  class { '::nodepool': }
+  class { '::nodepool':
+    install_mysql => true,
+  }
+
+  class { '::nodepool::builder': }
 
   file { '/home/nodepool/.config':
     ensure  => directory,
@@ -50,10 +54,4 @@ class opencontrail_ci::nodepool_launcher(
       Class['project_config'],
     ],
   }
-
-  class { '::nodepool::launcher':
-    statsd_host   => undef,
-    statsd_prefix => undef,
-  }
-
 }

--- a/modules/opencontrail_ci/manifests/params.pp
+++ b/modules/opencontrail_ci/manifests/params.pp
@@ -1,4 +1,5 @@
 class opencontrail_ci::params {
+  $cloud_credentials        = hiera('opencontrail_ci::cloud_credentials')
   $hosts                    = hiera('opencontrail_ci::hosts')
   $project_config_repo      = hiera('opencontrail_ci::project_config_repo')
   $common_packages          = [

--- a/modules/opencontrail_ci/manifests/zuul_executor.pp
+++ b/modules/opencontrail_ci/manifests/zuul_executor.pp
@@ -1,0 +1,8 @@
+class opencontrail_ci::zuul_executor inherits opencontrail_ci::params {
+
+  if ! defined(Class['zuul']) {
+    class { '::zuul': }
+  }
+
+  class { '::zuul::executor': }
+}

--- a/modules/opencontrail_ci/templates/nodepool/clouds.yaml.erb
+++ b/modules/opencontrail_ci/templates/nodepool/clouds.yaml.erb
@@ -1,0 +1,14 @@
+cache:
+  expiration:
+    server: 5
+    port: 5
+    floating-ip: 5
+clouds:
+  jnpr-contrail-ci:
+    auth:
+      auth_url: http://10.84.26.23:5000/
+      username: '<%= @cloud_credentials['jnpr-contrail-ci']['username'] %>'
+      password: '<%= @cloud_credentials['jnpr-contrail-ci']['password'] %>'
+      project_name: 'ci-zuulv3'
+    identity_api_version: '2'
+    volume_api_version: None


### PR DESCRIPTION
  Introduce a set of puppet manifests for configuring nodepool builder and
  launcher nodes, as well as zuul executor nodes.

  Hiera-Eyaml keys required (already added to contrail-hiera-private):
    - nodepool::mysql_password
    - nodepool::mysql_root_password
    - nodepool::nodepool_ssh_public_key
    - nodepool::nodepool_ssh_private_key
    - opencontrail_ci::cloud_credentials