### PR TITLE
Override compute endpoint URL

### DIFF
--- a/modules/opencontrail_ci/templates/nodepool/clouds.yaml.erb
+++ b/modules/opencontrail_ci/templates/nodepool/clouds.yaml.erb
@@ -12,3 +12,4 @@ clouds:
       project_name: 'ci-zuulv3'
     identity_api_version: '2'
     volume_api_version: None
+    compute_endpoint_override: http://10.84.26.23:8776/


### PR DESCRIPTION
Override compute API URL so it does not try to access internal/admin
endpoint.