### PR TITLE
Change the ZooKeeper port to 3389

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -74,3 +74,8 @@ nodepool::scripts_dir:              "/etc/project-config/nodepool/scripts"
 nodepool::require:                  Vcsrepo[/etc/project-config]
 nodepool::install_mysql:            false
 nodepool::install_nodepool_builder: false
+
+## ZooKeeper configuration
+# Override the port zookeeper is listening on to work around
+# access issue in the Juniper lab.
+zookeeper::client_port: 3389


### PR DESCRIPTION
Juniper Contrail Lab has a very limited access to the internet, so move
ZooKeeper port to one of the ports that are open.