### PR TITLE
default value for cloud_credentials

### DIFF
--- a/modules/opencontrail_ci/manifests/params.pp
+++ b/modules/opencontrail_ci/manifests/params.pp
@@ -1,5 +1,5 @@
 class opencontrail_ci::params {
-  $cloud_credentials        = hiera('opencontrail_ci::cloud_credentials')
+  $cloud_credentials        = hiera('opencontrail_ci::cloud_credentials', {})
   $hosts                    = hiera('opencontrail_ci::hosts')
   $project_config_repo      = hiera('opencontrail_ci::project_config_repo')
   $common_packages          = [


### PR DESCRIPTION
because not all node types need to have this value in hiera