### PR TITLE
Additional tweaks to shade OS configuration

### DIFF
--- a/modules/opencontrail_ci/templates/nodepool/clouds.yaml.erb
+++ b/modules/opencontrail_ci/templates/nodepool/clouds.yaml.erb
@@ -11,5 +11,15 @@ clouds:
       password: '<%= @cloud_credentials['jnpr-contrail-ci']['password'] %>'
       project_name: 'ci-zuulv3'
     identity_api_version: '2'
+    image_api_version: '2'
     volume_api_version: None
-    compute_endpoint_override: http://10.84.26.23:8776/
+    compute_endpoint_override: http://10.84.26.23:8774/v1.1/6d6d3f2ccd3740c69674e3770bf6a399
+    image_endpoint_override: http://10.84.26.23:9292/v2
+    network_endpoint_override: http://10.84.26.23:9697/
+    networks:
+      - name: test_net
+        routes_externally: False
+      - name: public
+        routes_externally: True
+      - name: ci-zuulv3-internal
+        nat_destination: True


### PR DESCRIPTION
Add a number of OpenStack configuration tweaks for shade/nodepool, to
support various quirks of our Juniper Contrail CI cloud.

- Update compute_endpoint_override to include tenant ID -- otherwise
  calls to nova return HTTP 300.
- Add additional endpoint overrides for neutron and glance[1]
- Define network topology so that shade can pick the right FIP pool.[2]

[1] That depends on a patch that hasn't yet been merged, and until then
we have to cary a small workaround for shade, deployed on
nodepool-builder locally.
[2] That doesn't do the right thing currently but hopefully will start
working once we teach shade of multiple FIP pools, and how to pick them
correctly.