### PR TITLE
Don't use fully-qualified hiera variables

### DIFF
--- a/modules/opencontrail_ci/manifests/gearman_allow_client.pp
+++ b/modules/opencontrail_ci/manifests/gearman_allow_client.pp
@@ -1,7 +1,7 @@
 define opencontrail_ci::gearman_allow_client {
   firewall { "300 allow gearman connection for ${title}":
     proto  => 'tcp',
-    dport  => hiera('::zuul::gearman_listen_port', 4730),
+    dport  => hiera('zuul::gearman_listen_port', 4730),
     source => $title,
     action => 'accept',
   }


### PR DESCRIPTION
Hiera has no concept of fully-qualified variables, and that actually
doesn't work as intended.