### PR TITLE
Change finger_port for ze01-jnpr

### DIFF
--- a/hiera/fqdn/ze01-jnpr.opencontrail.org.yaml
+++ b/hiera/fqdn/ze01-jnpr.opencontrail.org.yaml
@@ -1,0 +1,2 @@
+---
+zuul::finger_port: 7900


### PR DESCRIPTION
Until zuul-web can connect to zuul-executor ports directly we're using a
reverse proxy, and proxy user can't bind to port 79 on the zuul-web
node. Instead, change zuul-executor ports to >1024.