### PR TITLE
Override nodepool auth info using hiera variables (cherry-pick to development)

### DIFF
--- a/modules/opencontrail_ci/templates/nodepool/clouds.yaml.erb
+++ b/modules/opencontrail_ci/templates/nodepool/clouds.yaml.erb
@@ -6,10 +6,10 @@ cache:
 clouds:
   jnpr-contrail-ci:
     auth:
-      auth_url: http://10.84.26.23:5000/
+      auth_url: '<%= @cloud_credentials['jnpr-contrail-ci']['auth_url'] %>'
       username: '<%= @cloud_credentials['jnpr-contrail-ci']['username'] %>'
       password: '<%= @cloud_credentials['jnpr-contrail-ci']['password'] %>'
-      project_name: 'ci-zuulv3'
+      project_name: '<%= @cloud_credentials['jnpr-contrail-ci']['project'] %>'
     identity_api_version: '2'
     image_api_version: '2'
     volume_api_version: None


### PR DESCRIPTION
Allow for overriding nodepool auth variables using hiera.