### PR TITLE
Pull project-config repo on zuul-executor nodes

### DIFF
--- a/modules/opencontrail_ci/manifests/zuul_executor.pp
+++ b/modules/opencontrail_ci/manifests/zuul_executor.pp
@@ -2,6 +2,11 @@ class opencontrail_ci::zuul_executor inherits opencontrail_ci::params {
 
   include ::zuul::known_hosts
 
+  class { '::project_config':
+    url      => $::opencontrail_ci::params::project_config_repo,
+    revision => 'master',
+  }
+
   if ! defined(Class['zuul']) {
     class { '::zuul': }
   }


### PR DESCRIPTION
project-config repository provides site-variables.yaml for overriding
global zuul variables on the per-executor (per-region really) basis.

This commit checks out project-config repository on on zuul executor
nodes, for the future consumption.