### PR TITLE
Manage site-variables.yaml on executors

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -52,6 +52,7 @@ zuul::git_name:  "OpenContrail Zuul"
 
 # Generic configuration -- part of the zuul.conf template
 zuul::disk_limit_per_job:      2048
+zuul::site_variables_yaml_file: "/etc/project-config/zuul/site-variables.yaml"
 zuul::worker_private_key_file: "/var/lib/zuul/ssh/id_rsa"
 zuul::connections:
   - name:   'gerrit'


### PR DESCRIPTION
Copy site-variables.yaml from the checked out contrail-project-config repo,
so that zuul-executor nodes can override ansible variables on the
per-site basis (e.g. to use local mirrors).