### PR TITLE
Merge changes from development into production

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -52,6 +52,7 @@ zuul::git_name:  "OpenContrail Zuul"
 
 # Generic configuration -- part of the zuul.conf template
 zuul::disk_limit_per_job:      2048
+zuul::site_variables_yaml_file: "/etc/project-config/zuul/site-variables.yaml"
 zuul::worker_private_key_file: "/var/lib/zuul/ssh/id_rsa"
 zuul::connections:
   - name:   'gerrit'

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -8,6 +8,7 @@ opencontrail_ci::zookeeper::allowed_clients:
 opencontrail_ci::zuul_scheduler::gearman_allowed_clients:
   - 66.129.239.0/24 # Juniper Networks
   - 213.189.47.210  # OpenStack @ CodiLime
+opencontrail_ci::puppetmaster_port: 7999
 
 puppet::environment: development
 puppetdb::globals::version: 2.3.8-1puppetlabs1

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -66,6 +66,9 @@ zuul::connections:
     driver: 'github'
     sshkey: '/var/lib/zuul/ssh/id_rsa'
 
+  - name:   'stats'
+    driver: 'sql'
+
 zuul::zookeeper_hosts: "zuulv3-dev.opencontrail.org:3389"
 
 # Nodepool Builder and Launcher configuration

--- a/modules/opencontrail_ci/manifests/puppetmaster.pp
+++ b/modules/opencontrail_ci/manifests/puppetmaster.pp
@@ -96,4 +96,13 @@ class opencontrail_ci::puppetmaster(
     dport  => '8140',
     action => 'accept',
   }
+
+  firewall { '102 forward port 7999 to 8140 (puppet)':
+    table   => 'nat',
+    chain   => 'PREROUTING',
+    proto   => tcp,
+    dport   => '7999',
+    jump    => 'REDIRECT',
+    toports => '8140',
+  }
 }

--- a/modules/opencontrail_ci/manifests/server.pp
+++ b/modules/opencontrail_ci/manifests/server.pp
@@ -9,6 +9,7 @@ class opencontrail_ci::server inherits opencontrail_ci::params {
   class { '::puppet':
     server                    => false,
     puppetmaster              => $::opencontrail_ci::params::hosts['puppetmaster'],
+    port                      => hiera('opencontrail_ci::puppetmaster_port', 8140),
     agent_additional_settings => {
       stringify_facts => false,
     }

--- a/modules/opencontrail_ci/manifests/users.pp
+++ b/modules/opencontrail_ci/manifests/users.pp
@@ -93,7 +93,7 @@ class opencontrail_ci::users {
 
   accounts::user { 'wurbanski':
     ensure        => present,
-    comment       => 'Wojciech Urbański',
+    comment       => 'Wojciech Urbanski',
     groups        => [ 'sudo' ],
     uid           => '1108',
     gid           => '1108',

--- a/modules/opencontrail_ci/manifests/zuul_executor.pp
+++ b/modules/opencontrail_ci/manifests/zuul_executor.pp
@@ -2,6 +2,11 @@ class opencontrail_ci::zuul_executor inherits opencontrail_ci::params {
 
   include ::zuul::known_hosts
 
+  class { '::project_config':
+    url      => $::opencontrail_ci::params::project_config_repo,
+    revision => 'master',
+  }
+
   if ! defined(Class['zuul']) {
     class { '::zuul': }
   }

--- a/modules/opencontrail_ci/manifests/zuul_scheduler.pp
+++ b/modules/opencontrail_ci/manifests/zuul_scheduler.pp
@@ -12,10 +12,14 @@ class opencontrail_ci::zuul_scheduler(
     action => 'accept',
   }
 
-  firewall {'201 accept all to 443 for Apache2':
+  firewall { '201 accept all to 443 for Apache2':
     proto  => 'tcp',
     dport  => '443',
     action => 'accept',
+  }
+
+  package { 'python3-mysqldb':
+      ensure => installed,
   }
 
   include ::zuul::known_hosts
@@ -25,7 +29,10 @@ class opencontrail_ci::zuul_scheduler(
   class { '::zuul::web': }
   class { '::zuul::scheduler':
     layout_dir => $::project_config::zuul_layout_dir,
-    require    => $::project_config::config_dir,
+    require    => [
+        $::project_config::config_dir,
+        Package['python3-mysqldb'],
+    ],
   }
   opencontrail_ci::gearman_allow_client { $gearman_allowed_clients: }
 }

--- a/modules/opencontrail_ci/templates/logserver.vhost.erb
+++ b/modules/opencontrail_ci/templates/logserver.vhost.erb
@@ -19,33 +19,6 @@
         Require all granted
     </Directory>
 
-    Redirect permanent / https://<%= @vhost_name %>/
-</VirtualHost>
-
-<VirtualHost *:443>
-    ServerName <%= @vhost_name %>
-    DocumentRoot <%= @docroot %>
-
-    SSLEngine on
-    SSLProtocol All -SSLv2 -SSLv3
-    SSLCipherSuite ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!AES256:!aNULL:!eNULL:!MD5:!DSS:!PSK:!SRP
-    SSLHonorCipherOrder on
-    SSLCertificateFile <%= @cert_file %>
-    SSLCertificateKeyFile <%= @key_file %>
-
-    LogLevel warn
-    ErrorLog /var/log/apache2/ssl-<%= @vhost_name %>_error.log
-    CustomLog /var/log/apache2/ssl-<%= @vhost_name %>_access.log combined
-    ServerSignature Off
-
-    <Directory <%= @docroot %>>
-        Options Indexes FollowSymLinks MultiViews
-        AllowOverride None
-        AllowOverrideList Redirect RedirectMatch
-        Satisfy Any
-        Require all granted
-    </Directory>
-
     <Directory /usr/local/lib/python2.7/dist-packages/os_loganalyze>
         <Files wsgi.py>
             Require all granted


### PR DESCRIPTION
This merge fixes a small locale-specific puppet error when it's being ran manually, as well as introducing site-specific variables for zuul executors to override mirrors on a per-site basis.