### PR TITLE
change puppetmaster port to 7999 on development

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -8,6 +8,7 @@ opencontrail_ci::zookeeper::allowed_clients:
 opencontrail_ci::zuul_scheduler::gearman_allowed_clients:
   - 66.129.239.0/24 # Juniper Networks
   - 213.189.47.210  # OpenStack @ CodiLime
+opencontrail_ci::puppetmaster_port: 7999
 
 puppet::environment: development
 puppetdb::globals::version: 2.3.8-1puppetlabs1

--- a/modules/opencontrail_ci/manifests/puppetmaster.pp
+++ b/modules/opencontrail_ci/manifests/puppetmaster.pp
@@ -96,4 +96,13 @@ class opencontrail_ci::puppetmaster(
     dport  => '8140',
     action => 'accept',
   }
+
+  firewall { '102 forward port 7999 to 8140 (puppet)':
+    table   => 'nat',
+    chain   => 'PREROUTING',
+    proto   => tcp,
+    dport   => '7999',
+    jump    => 'REDIRECT',
+    toports => '8140',
+  }
 }

--- a/modules/opencontrail_ci/manifests/server.pp
+++ b/modules/opencontrail_ci/manifests/server.pp
@@ -9,6 +9,7 @@ class opencontrail_ci::server inherits opencontrail_ci::params {
   class { '::puppet':
     server                    => false,
     puppetmaster              => $::opencontrail_ci::params::hosts['puppetmaster'],
+    port                      => hiera('opencontrail_ci::puppetmaster_port', 8140),
     agent_additional_settings => {
       stringify_facts => false,
     }


### PR DESCRIPTION
there is no connectivity to 8140 on the ci-puppetmaster2 for development vms on cluster A