### PR TITLE
Send job stats from Zuul to SQL db

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -66,6 +66,9 @@ zuul::connections:
     driver: 'github'
     sshkey: '/var/lib/zuul/ssh/id_rsa'
 
+  - name:   'stats'
+    driver: 'sql'
+
 zuul::zookeeper_hosts: "zuulv3-dev.opencontrail.org:3389"
 
 # Nodepool Builder and Launcher configuration

--- a/modules/opencontrail_ci/manifests/zuul_scheduler.pp
+++ b/modules/opencontrail_ci/manifests/zuul_scheduler.pp
@@ -12,10 +12,14 @@ class opencontrail_ci::zuul_scheduler(
     action => 'accept',
   }
 
-  firewall {'201 accept all to 443 for Apache2':
+  firewall { '201 accept all to 443 for Apache2':
     proto  => 'tcp',
     dport  => '443',
     action => 'accept',
+  }
+
+  package { 'python3-mysqldb':
+      ensure => installed,
   }
 
   include ::zuul::known_hosts
@@ -25,7 +29,10 @@ class opencontrail_ci::zuul_scheduler(
   class { '::zuul::web': }
   class { '::zuul::scheduler':
     layout_dir => $::project_config::zuul_layout_dir,
-    require    => $::project_config::config_dir,
+    require    => [
+        $::project_config::config_dir,
+        Package['python3-mysqldb'],
+    ],
   }
   opencontrail_ci::gearman_allow_client { $gearman_allowed_clients: }
 }


### PR DESCRIPTION
Also require python3-mysqldb. It is not listed in the requirements.txt,
however Zuul fails silently whenever mysql is used as connection.