### PR TITLE
Use forked puppet-nodepool module for kazoo logging

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,8 +13,7 @@ mod 'openstackci/logrotate',
         :git    => 'https://github.com/openstack-infra/puppet-logrotate',
         :commit => '5cfa447'
 mod 'openstackci/nodepool',
-        :git    => 'https://github.com/openstack-infra/puppet-nodepool',
-        :commit => 'e2b8c27'
+        :git    => 'https://github.com/codilime/puppet-nodepool'
 mod 'openstackci/pip',
         :git    => 'https://github.com/openstack-infra/puppet-pip',
         :commit => 'bde44d1'


### PR DESCRIPTION
We need to track down a reason for Kazoo not reconnecting to the
ZooKeepr server, and for that we need extra logging enabled - use forked
module that enables it.