### PR TITLE
Add /etc/ssl/certs to zuul untrusted_ro_paths

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -55,7 +55,8 @@ zuul::git_name:  "OpenContrail Zuul"
 zuul::disk_limit_per_job:      2048
 zuul::site_variables_yaml_file: "/etc/project-config/zuul/site-variables.yaml"
 zuul::worker_private_key_file: "/var/lib/zuul/ssh/id_rsa"
-zuul::trusted_ro_paths: ["/etc/ssl/certs", "/usr/share/ca-certificates", "/var/lib/zuul/ssh"]
+zuul::trusted_ro_paths: ["/etc/ssl/certs", "/var/lib/zuul/ssh"]
+zuul::untrusted_ro_paths: ["/etc/ssl/certs"]
 zuul::connections:
   - name:   'gerrit'
     driver: 'gerrit'


### PR DESCRIPTION
Some of our roles require access to CA bundles for verifying SSL
certificates, and while one of the previous commits added /etc/ssl/certs
to trusted_ro_paths, we've missed the sibling used for untrusted roles -
make sure it's fixed.

Also, remove /usr/share/ca-certificates/ as bubblewrap already creates a
RO bind for /usr.