### PR TITLE
Make ::nodepool require 'project_config' class

### DIFF
--- a/modules/opencontrail_ci/manifests/nodepool_builder.pp
+++ b/modules/opencontrail_ci/manifests/nodepool_builder.pp
@@ -11,6 +11,7 @@ class opencontrail_ci::nodepool_builder(
 
   class { '::nodepool':
     install_mysql => true,
+    require       => Class['project_config'],
   }
 
   class { '::nodepool::builder': }

--- a/modules/opencontrail_ci/manifests/nodepool_launcher.pp
+++ b/modules/opencontrail_ci/manifests/nodepool_launcher.pp
@@ -9,7 +9,9 @@ class opencontrail_ci::nodepool_launcher(
     }
   }
 
-  class { '::nodepool': }
+  class { '::nodepool':
+    require => Class['project_config'],
+  }
 
   file { '/home/nodepool/.config':
     ensure  => directory,


### PR DESCRIPTION
Set the dependency explicitly, so that nodepool always refreshes
project-config repository before it copies files over to /etc/nodepool.