### PR TITLE
Ubuntu Package Mirror

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -56,3 +56,8 @@ node /repo.opencontrail.org/ {
   class { '::opencontrail_ci::pulp_server': }
   class { '::opencontrail_ci::pulp_public_repo': }
 }
+
+node /aptmirror\d+(-dev|-jnpr|-ttu)?.opencontrail.org/ {
+      class { '::opencontrail_ci::server': }
+      class { '::opencontrail_ci::aptmirror': }
+}

--- a/modules/opencontrail_ci/manifests/apt_mirror.pp
+++ b/modules/opencontrail_ci/manifests/apt_mirror.pp
@@ -1,0 +1,72 @@
+class opencontrail_ci::apt_mirror (
+  $docroot = '/var/www/html/',
+  $package_cache = '/var/spool/apt-mirror',
+  $vhost_template = 'opencontrail_ci/apt_mirror.vhost.erb',
+  $mirror_list = '/etc/apt/mirror.list'
+) inherits opencontrail_ci::params {
+
+  include ::httpd
+
+  firewall { '200 accept all to 80 for Apache2':
+    proto  => 'tcp',
+    dport  => '80',
+    action => 'accept',
+  }
+
+  accounts::user { 'apt-mirror':
+    ensure        => present,
+    comment       => 'apt-mirror cronjob',
+  }
+
+  package { 'apt-mirror':
+    ensure => installed,
+  }
+
+  cron { 'apt-mirror':
+    command => '/usr/bin/apt-mirror > /var/spool/apt-mirror/var/cron.log',
+    user    => 'apt-mirror',
+    hour    => 1,
+    minute  => 0,
+    require => [
+        Package['apt-mirror'],
+        User['apt-mirror'],
+    ],
+  }
+
+  file { $docroot:
+    ensure => 'directory',
+  }
+
+  file { "${docroot}/ubuntu":
+    ensure => 'link',
+    target => "${package_cache}/mirror/us.archive.ubuntu.com/ubuntu",
+    notify => Service['httpd'],
+  }
+
+  file { $package_cache:
+    ensure => 'directory',
+    owner  => 'apt-mirror',
+    group  => 'apt-mirror',
+    mode   => '0755',
+  }
+
+  file { $mirror_list:
+    owner   => 'apt-mirror',
+    group   => 'apt-mirror',
+    mode    => '0655',
+    content => template('opencontrail_ci/apt_mirror.mirror.list.erb'),
+    require => Package['apt-mirror'],
+  }
+
+  ::httpd::vhost { $::clientcert:
+    port       => 80,
+    docroot    => $docroot,
+    priority   => '0',
+    ssl        => false,
+    template   => $vhost_template,
+    vhost_name => $::clientcert,
+    require    => [
+        File[$docroot],
+    ],
+  }
+}

--- a/modules/opencontrail_ci/templates/apt_mirror.mirror.list.erb
+++ b/modules/opencontrail_ci/templates/apt_mirror.mirror.list.erb
@@ -1,0 +1,27 @@
+############# config ##################
+#
+# set base_path    /var/spool/apt-mirror
+#
+# set mirror_path  $base_path/mirror
+# set skel_path    $base_path/skel
+# set var_path     $base_path/var
+# set cleanscript $var_path/clean.sh
+# set defaultarch  <running host architecture>
+# set postmirror_script $var_path/postmirror.sh
+# set run_postmirror 0
+set nthreads     20
+set _tilde 0
+#
+############# end config ##############
+
+deb-amd64 http://us.archive.ubuntu.com/ubuntu trusty main main/debian-installer restricted restricted/debian-installer universe multiverse
+deb-amd64 http://us.archive.ubuntu.com/ubuntu trusty-security main main/debian-installer restricted universe multiverse
+deb-amd64 http://us.archive.ubuntu.com/ubuntu trusty-updates main main/debian-installer restricted universe multiverse
+deb-amd64 http://us.archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse
+
+deb-amd64 http://us.archive.ubuntu.com/ubuntu xenial main main/debian-installer restricted restricted/debian-installer universe multiverse
+deb-amd64 http://us.archive.ubuntu.com/ubuntu xenial-security main main/debian-installer restricted universe multiverse
+deb-amd64 http://us.archive.ubuntu.com/ubuntu xenial-updates main main/debian-installer restricted universe multiverse
+deb-amd64 http://us.archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse
+
+clean http://us.archive.ubuntu.com/ubuntu

--- a/modules/opencontrail_ci/templates/apt_mirror.vhost.erb
+++ b/modules/opencontrail_ci/templates/apt_mirror.vhost.erb
@@ -1,0 +1,23 @@
+# ************************************
+# Managed by Puppet
+# ************************************
+
+<VirtualHost *:80>
+    ServerName <%= @vhost_name %>
+    DocumentRoot <%= @docroot %>
+
+    LogLevel warn
+    ErrorLog /var/log/apache2/<%= @vhost_name %>_error.log
+    CustomLog /var/log/apache2/<%= @vhost_name %>_access.log combined
+    ServerSignature Off
+
+    <Directory <%= @docroot %>>
+        Options Indexes FollowSymLinks MultiViews
+        AllowOverride None
+        AllowOverrideList Redirect RedirectMatch
+        Satisfy Any
+        Require all granted
+    </Directory>
+
+</VirtualHost>
+


### PR DESCRIPTION
Puppet manifest for Ubuntu Package Mirror server. It installs and configures
apt-mirror and Apache2.