### PR TITLE
Install python-jmespath on zuul executors

### DIFF
--- a/modules/opencontrail_ci/manifests/zuul_executor.pp
+++ b/modules/opencontrail_ci/manifests/zuul_executor.pp
@@ -13,5 +13,10 @@ class opencontrail_ci::zuul_executor inherits opencontrail_ci::params {
     }
   }
 
+  package { "python3-jmespath":
+    ensure => present,
+    before => Class['::zuul::executor'],
+  }
+
   class { '::zuul::executor': }
 }


### PR DESCRIPTION
ansible json_query module depends on python-jmespath being available on
the executor - make sure this is installed before we configure
zuul-executor, so that it's available as soon as it starts.