### PR TITLE
Add python3-mysqldb and mysql-client for executors

### DIFF
--- a/modules/opencontrail_ci/manifests/zuul_executor.pp
+++ b/modules/opencontrail_ci/manifests/zuul_executor.pp
@@ -2,6 +2,14 @@ class opencontrail_ci::zuul_executor inherits opencontrail_ci::params {
 
   include ::zuul::known_hosts
 
+  package { 'python3-mysqldb':
+      ensure => installed,
+  }
+
+  package { 'mysql-client':
+      ensure => installed,
+  }
+
   firewall { '100 accept all to 3306 - build number db':
     proto  => 'tcp',
     dport  => '3306',


### PR DESCRIPTION
Those packages are required to properly generate build number for our
periodic builds.