### PR TITLE
Synchronize CI repos every 24 hours

### DIFF
--- a/modules/opencontrail_ci/files/pulp/repo_sync.sh
+++ b/modules/opencontrail_ci/files/pulp/repo_sync.sh
@@ -1,0 +1,3 @@
+for i in centos74 centos74-updates centos74-extras centos74-epel; do
+    pulp-admin rpm repo sync run --bg --repo-id=$i;
+done

--- a/modules/opencontrail_ci/manifests/pulp_ci_repo.pp
+++ b/modules/opencontrail_ci/manifests/pulp_ci_repo.pp
@@ -60,4 +60,23 @@ class opencontrail_ci::pulp_ci_repo inherits opencontrail_ci::params {
         checksum_type => 'sha256',
         feed          => 'http://mirrors.mit.edu/epel/7/x86_64/',
     }
+    
+    file { '/opt/opencontrail_ci/repo_sync.sh':
+        ensure  => file,
+        source  => 'puppet:///modules/opencontrail_ci/pulp/repo_sync.sh',
+        mode    => '0700',
+        owner   => 'root',
+        require => [
+            File['/opt/opencontrail_ci']
+        ],
+    }
+
+    cron { 'sync_repos':
+        command => '/opt/opencontrail_ci/repo_sync.sh'
+        user    => 'root',
+        hour    => '1',
+        require => [
+            File['/opt/opencontrail_ci/repo_sync.sh']
+        ],
+    }
 }


### PR DESCRIPTION
Our mirrors are not getting synchronized right now and we may use
packages that we shouldn't use any longer. We need to fix it and also
prepare for CentOS 7.5.